### PR TITLE
Login endpoint refactor from accesstoken

### DIFF
--- a/server/src/Routes/authRoutes.ts
+++ b/server/src/Routes/authRoutes.ts
@@ -1,7 +1,6 @@
 import { Router } from "express";
 import { AuthController } from "../Controllers/AuthController";
 import pool from "../db";
-import authenticateJWT from "../middleware/authenticateJWT";
 
 const authController = new AuthController(pool)
 const router  = Router();
@@ -18,8 +17,7 @@ router.post("/login", authController.login);
 router.post("/refresh-token", authController.refreshToken);
 
 // PUT
-// @ts-expect-error TODO GET RID OF THIS I HATE TYPESCRIPT
-router.put("/logout", authenticateJWT, authController.logout);
+router.put("/logout", authController.logout);
 
 // DELETE
 


### PR DESCRIPTION
We shouldnt have been checking the accesstoken for logout but the refreshtoken, since accesstoken is now store in memory of the client and not localstorage and it just doesnt make sense. What logout should accomplish is clearing the cookies and clearing the refresh token refresh on user table