### PR TITLE
Dynamic route bug

### DIFF
--- a/client/src/index.html
+++ b/client/src/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="./output.css" />
+    <link rel="stylesheet" href="/output.css" />
     <title>Makedle</title>
     <link rel="icon" type="image/png" href="/images/logo.png" />
   </head>

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -7,6 +7,7 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'bundle.js',
+    publicPath: '/'
   },
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],


### PR DESCRIPTION
Resolves `Uncaught SyntaxError: Unexpected token '<' ` when navigating to dynamic route ie /games/1. Root cause is index.html was being served at every route not defined, but had relative references to the bundle and css files. Ex of what it should be `<script defer src="/bundle.js"></script></head>`
