### PR TITLE
Front end Auth protection for create game page / make game endpoints public

### DIFF
--- a/client/src/components/PageHeader.tsx
+++ b/client/src/components/PageHeader.tsx
@@ -5,7 +5,9 @@ import { Bell, Upload, User } from "lucide-react";
 import { useAuth } from "../context/AuthProvider";
 import ProfileMenu from "./ProfileMenu";
 import Sidebar from "./Sidebar";
-import LoginSignUpModal from "../pages/login/LoginSignUpModal";
+import LoginSignUpModal, {
+  LoginModalView,
+} from "../pages/login/LoginSignUpModal";
 
 export default function PageHeader() {
   const { appUser } = useAuth();
@@ -46,6 +48,7 @@ export default function PageHeader() {
         <LoginSignUpModal
           isOpen={showLoginModal}
           onClose={() => setShowLoginModal(false)}
+          initialView={LoginModalView.LOGIN}
         />
       </div>
     );

--- a/client/src/components/PageHeader.tsx
+++ b/client/src/components/PageHeader.tsx
@@ -5,7 +5,7 @@ import { Bell, Upload, User } from "lucide-react";
 import { useAuth } from "../context/AuthProvider";
 import ProfileMenu from "./ProfileMenu";
 import Sidebar from "./Sidebar";
-import LoginRegisterModal from "../pages/login/LoginRegisterModal";
+import LoginSignUpModal from "../pages/login/LoginSignUpModal";
 
 export default function PageHeader() {
   const { appUser } = useAuth();
@@ -43,7 +43,7 @@ export default function PageHeader() {
             <div>Sign In</div>
           </Button>
         )}
-        <LoginRegisterModal
+        <LoginSignUpModal
           isOpen={showLoginModal}
           onClose={() => setShowLoginModal(false)}
         />

--- a/client/src/components/common/PageLayout.tsx
+++ b/client/src/components/common/PageLayout.tsx
@@ -2,16 +2,20 @@ import React, { ReactNode } from "react";
 
 interface PageLayoutProps {
   title: string;
+  description?: string;
   children: ReactNode;
 }
 
-const PageLayout: React.FC<PageLayoutProps> = ({ title, children }) => {
+const PageLayout: React.FC<PageLayoutProps> = ({
+  title,
+  description,
+  children,
+}) => {
   return (
     <div className="flex flex-col gap-4 items-center p-4">
       <h1 className="text-3xl font-semibold text-gray-800">{title}</h1>
-      <div className="flex-grow p-6 rounded-md">
-        {children}
-      </div>
+      {description && <h2 className="text-xl text-gray-400">{description}</h2>}
+      <div className="flex-grow p-6 rounded-md">{children}</div>
     </div>
   );
 };

--- a/client/src/pages/__tests__/LoginPage.test.tsx
+++ b/client/src/pages/__tests__/LoginPage.test.tsx
@@ -15,7 +15,7 @@ describe("LoginPage", () => {
   test("renders the login page", () => {
     render(
       <AuthProvider>
-        <LoginPage goToRegister={() => {}} />
+        <LoginPage goToSignUp={() => {}} />
       </AuthProvider>
     );
 
@@ -30,7 +30,7 @@ describe("LoginPage", () => {
   test("updates state on input change", () => {
     render(
       <AuthProvider>
-        <LoginPage goToRegister={() => {}} />
+        <LoginPage goToSignUp={() => {}} />
       </AuthProvider>
     );
 
@@ -50,7 +50,7 @@ describe("LoginPage", () => {
 
     render(
       <AuthProvider>
-        <LoginPage goToRegister={() => {}} />
+        <LoginPage goToSignUp={() => {}} />
       </AuthProvider>
     );
 
@@ -75,7 +75,7 @@ describe("LoginPage", () => {
 
     render(
       <AuthProvider>
-        <LoginPage goToRegister={() => {}} />
+        <LoginPage goToSignUp={() => {}} />
       </AuthProvider>
     );
 

--- a/client/src/pages/create/CreatePage.tsx
+++ b/client/src/pages/create/CreatePage.tsx
@@ -8,6 +8,8 @@ import PageLayout from "../../components/common/PageLayout";
 import ColorIndicator from "../../components/common/ColorIndicator";
 import CreatePageForm from "./CreatePageForm";
 import toast from "react-hot-toast";
+import { useAuth } from "../../context/AuthProvider";
+import SignInToCreatePage from "./SignInToCreatePage";
 
 interface IFormData {
   name: string;
@@ -30,6 +32,7 @@ const initFormData: IFormData = {
 export default function CreatePage() {
   const [form, setForm] = useState<IFormData>(initFormData);
   const [preview, setPreview] = useState<string | null>(null);
+  const { appUser } = useAuth();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const httpService = useHttpService();
 
@@ -102,7 +105,7 @@ export default function CreatePage() {
     return formData;
   };
 
-  return (
+  return appUser ? (
     <PageLayout title="Create a game!">
       <div className="grid grid-cols-2 gap-20">
         <CreatePageForm
@@ -134,5 +137,7 @@ export default function CreatePage() {
         </Button>
       </div>
     </PageLayout>
+  ) : (
+    <SignInToCreatePage />
   );
 }

--- a/client/src/pages/create/SignInToCreatePage.tsx
+++ b/client/src/pages/create/SignInToCreatePage.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from "react";
+import PageLayout from "../../components/common/PageLayout";
+import { CircleCheckBig } from "lucide-react";
+import Button from "../../components/common/Button";
+import LoginSignUpModal, { LoginModalView } from "../login/LoginSignUpModal";
+
+export default function SignInToCreatePage() {
+  const [modalView, setModalView] = useState<
+    LoginModalView.LOGIN | LoginModalView.SIGNUP
+  >(LoginModalView.LOGIN);
+  const [showModal, setShowModal] = useState<boolean>(false);
+
+  const openModal = (view: LoginModalView.LOGIN | LoginModalView.SIGNUP) => {
+    setModalView(view);
+    setShowModal(true);
+  };
+
+  const bulletPoints = [
+    "Create a makedle game on any possible topic",
+    "Share your game with the world or keep it private with your friends",
+    "Track your game's statistics",
+  ];
+
+  return (
+    <PageLayout
+      title="Create Your Own Wordle-like Game"
+      description="Have a game idea? Join Makedle"
+    >
+      <div className="flex flex-col gap-8">
+        <div className="flex flex-col gap-4">
+          {bulletPoints.map((bullet) => (
+            <div className="flex gap-2" key={bullet}>
+              <CircleCheckBig />
+              <div className="text-xl">{bullet}</div>
+            </div>
+          ))}
+        </div>
+        <div className="flex flex-col gap-4">
+          <Button
+            onClick={() => openModal(LoginModalView.SIGNUP)}
+            className="self-center w-[150px]"
+          >
+            Sign Up
+          </Button>
+          <div className="self-center">
+            Already on Makedle?{" "}
+            <span
+              className=" underline font-bold hover:text-green-300 cursor-pointer"
+              onClick={() => openModal(LoginModalView.LOGIN)}
+            >
+              Log in
+            </span>
+          </div>
+        </div>
+      </div>
+      <LoginSignUpModal
+        isOpen={showModal}
+        onClose={() => setShowModal(false)}
+        initialView={modalView}
+      />
+    </PageLayout>
+  );
+}

--- a/client/src/pages/login/LoginPage.tsx
+++ b/client/src/pages/login/LoginPage.tsx
@@ -10,10 +10,10 @@ type LoginFormUser = {
 };
 
 interface ILoginPageProps {
-  goToRegister: () => void;
+  goToSignUp: () => void;
 }
 
-export default function LoginPage({ goToRegister }: ILoginPageProps) {
+export default function LoginPage({ goToSignUp }: ILoginPageProps) {
   const [user, setUser] = useState<LoginFormUser>({ email: "", password: "" });
   const { handleLogin } = useAuth();
   const navigate = useNavigate();
@@ -65,7 +65,7 @@ export default function LoginPage({ goToRegister }: ILoginPageProps) {
       </form>
       <div
         className="underline text-gray-400 hover:text-green-300 cursor-pointer"
-        onClick={goToRegister}
+        onClick={goToSignUp}
       >
         Join Makedle
       </div>

--- a/client/src/pages/login/LoginSignUpModal.tsx
+++ b/client/src/pages/login/LoginSignUpModal.tsx
@@ -1,25 +1,25 @@
 import React, { useState } from "react";
 import Modal from "../../components/common/Modal";
 import LoginPage from "./LoginPage";
-import RegisterPage from "./RegisterPage";
+import SignUpPage from "./SignUpPage";
 
-interface ILoginRegisterModalProps {
+interface ILoginSignUpModalProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
-export default function LoginRegisterModal({
+export default function LoginSignUpModal({
   isOpen,
   onClose,
-}: ILoginRegisterModalProps) {
+}: ILoginSignUpModalProps) {
   const [showLogin, setShowLogin] = useState(true);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       {showLogin ? (
-        <LoginPage goToRegister={() => setShowLogin(false)} />
+        <LoginPage goToSignUp={() => setShowLogin(false)} />
       ) : (
-        <RegisterPage goToLogin={() => setShowLogin(true)} />
+        <SignUpPage goToLogin={() => setShowLogin(true)} />
       )}
     </Modal>
   );

--- a/client/src/pages/login/LoginSignUpModal.tsx
+++ b/client/src/pages/login/LoginSignUpModal.tsx
@@ -1,18 +1,31 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Modal from "../../components/common/Modal";
 import LoginPage from "./LoginPage";
 import SignUpPage from "./SignUpPage";
 
+export enum LoginModalView {
+  LOGIN = "login",
+  SIGNUP = "signup",
+}
+
 interface ILoginSignUpModalProps {
   isOpen: boolean;
   onClose: () => void;
+  initialView: LoginModalView.LOGIN | LoginModalView.SIGNUP;
 }
 
 export default function LoginSignUpModal({
   isOpen,
   onClose,
+  initialView,
 }: ILoginSignUpModalProps) {
-  const [showLogin, setShowLogin] = useState(true);
+  const [showLogin, setShowLogin] = useState(
+    initialView === LoginModalView.LOGIN
+  );
+
+  useEffect(() => {
+    setShowLogin(initialView === LoginModalView.LOGIN);
+  }, [initialView]);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>

--- a/client/src/pages/login/SignUpPage.tsx
+++ b/client/src/pages/login/SignUpPage.tsx
@@ -81,7 +81,7 @@ export default function SignUpPage({ goToLogin }: ISignUpPageProps) {
         className="underline text-gray-400 hover:text-green-300 cursor-pointer"
         onClick={goToLogin}
       >
-        Sign in
+        Already on Makedle?
       </div>
     </div>
   );

--- a/client/src/pages/login/SignUpPage.tsx
+++ b/client/src/pages/login/SignUpPage.tsx
@@ -4,7 +4,7 @@ import Button from "../../components/common/Button";
 import _isEmpty from "lodash/isEmpty";
 import toast from "react-hot-toast";
 
-interface IRegisterPageProps {
+interface ISignUpPageProps {
   goToLogin: () => void;
 }
 
@@ -14,7 +14,7 @@ const initNewUser = {
   password: "",
 };
 
-export default function RegisterPage({ goToLogin }: IRegisterPageProps) {
+export default function SignUpPage({ goToLogin }: ISignUpPageProps) {
   const [newUser, setNewUser] = useState(initNewUser);
   const httpService = useHttpService();
 

--- a/server/src/Routes/gameRoutes.ts
+++ b/server/src/Routes/gameRoutes.ts
@@ -19,9 +19,9 @@ const gameController = new GameController(pool);
 const router = Router();
 
 //GET
-router.get("/games", authenticateJWT, gameController.getGames);
-router.get("/games/:id", authenticateJWT, gameController.getGameById);
-router.get("/games/:id/words", authenticateJWT, gameController.getWordsByGameId);
+router.get("/games", gameController.getGames);
+router.get("/games/:id", gameController.getGameById);
+router.get("/games/:id/words", gameController.getWordsByGameId);
 
 //POST
 router.post(


### PR DESCRIPTION
I want people to be able to play games without having to sign in we just wont track their statistics on game win and will again prompt them to create an account. Additionally, create page is only accessible if you are authenticated otherwise we show a prompt to login.

Game endpoints now public took off JWT middleware
Create endpoint maintains JWT middleware