### PR TITLE
Loading context and Pagelayout

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,17 +9,25 @@ import GamesPage from "./pages/games/GamesPage";
 import CreatePage from "./pages/create/CreatePage";
 
 const App = () => {
-  const { setAccessToken, setAppUser } = useAuth();
+  const { setAccessToken, setAppUser, setLoadingAppUser } = useAuth();
 
   useEffect(() => {
     initUserData();
   }, []);
 
   const initUserData = async () => {
-    const response = await httpService.get("/init");
-    const { user, token } = response.data;
-    setAccessToken(token);
-    setAppUser(user);
+    setLoadingAppUser(true);
+    try {
+      const response = await httpService.get("/init");
+      const { user, token } = response.data;
+      setAccessToken(token);
+      setAppUser(user);
+    } catch {
+      setAccessToken(null);
+      setAppUser(null);
+    } finally{
+      setLoadingAppUser(false);
+    } 
   };
 
   return (

--- a/client/src/components/common/PageLayout.tsx
+++ b/client/src/components/common/PageLayout.tsx
@@ -1,19 +1,26 @@
 import React, { ReactNode } from "react";
+import LoadingPage from "../../pages/LoadingPage";
 
 interface PageLayoutProps {
-  title: string;
+  title?: string;
   description?: string;
   children: ReactNode;
+  loading?: boolean;
 }
 
 const PageLayout: React.FC<PageLayoutProps> = ({
   title,
   description,
   children,
+  loading = false,
 }) => {
-  return (
+  return loading ? (
+    <LoadingPage />
+  ) : (
     <div className="flex flex-col gap-4 items-center p-4">
-      <h1 className="text-3xl font-semibold text-gray-800">{title}</h1>
+      {title && (
+        <h1 className="text-3xl font-semibold text-gray-800">{title}</h1>
+      )}
       {description && <h2 className="text-xl text-gray-400">{description}</h2>}
       <div className="flex-grow p-6 rounded-md">{children}</div>
     </div>

--- a/client/src/context/AuthProvider.tsx
+++ b/client/src/context/AuthProvider.tsx
@@ -16,10 +16,12 @@ type User = {
 type AuthContext = {
   accessToken?: string | null;
   appUser?: User | null;
+  loadingAppUser: boolean;
   handleLogin: (user: User) => Promise<AxiosResponse<{ token: string }>>;
   handleLogout: () => Promise<void>;
   setAccessToken: (state: string | null) => void;
   setAppUser: (state: User | null) => void;
+  setLoadingAppUser: (state: boolean) => void;
 };
 
 const AuthContext = createContext<AuthContext | undefined>(undefined);
@@ -29,11 +31,13 @@ type AuthProviderProps = PropsWithChildren;
 export default function AuthProvider({ children }: AuthProviderProps) {
   const [accessToken, setAccessToken] = useState<string | null>(null);
   const [appUser, setAppUser] = useState<User | null>(null);
+  const [loadingAppUser, setLoadingAppUser] = useState<boolean>(true);
 
 
   async function handleLogin(
     user: User
   ): Promise<AxiosResponse<{ token: string }>> {
+    setLoadingAppUser(true);
     try {
       const response = await httpService.post("/login", user);
       const token = response.data?.token;
@@ -46,6 +50,8 @@ export default function AuthProvider({ children }: AuthProviderProps) {
       setAppUser(null);
       toast.error("Login failed");
       return Promise.reject(error);
+    } finally {
+      setLoadingAppUser(false);
     }
   }
 
@@ -68,10 +74,12 @@ export default function AuthProvider({ children }: AuthProviderProps) {
       value={{
         accessToken,
         appUser,
+        loadingAppUser,
         handleLogin,
         handleLogout,
         setAccessToken,
         setAppUser,
+        setLoadingAppUser
       }}
     >
       {children}

--- a/client/src/pages/LoadingPage.tsx
+++ b/client/src/pages/LoadingPage.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import PageLayout from "../components/common/PageLayout";
+import LoadingSpinner from "../components/common/LoadingSpinner";
+
+export default function LoadingPage() {
+  return (
+    <PageLayout>
+      <LoadingSpinner />
+    </PageLayout>
+  );
+}

--- a/client/src/pages/create/CreatePage.tsx
+++ b/client/src/pages/create/CreatePage.tsx
@@ -32,7 +32,7 @@ const initFormData: IFormData = {
 export default function CreatePage() {
   const [form, setForm] = useState<IFormData>(initFormData);
   const [preview, setPreview] = useState<string | null>(null);
-  const { appUser } = useAuth();
+  const { appUser, loadingAppUser } = useAuth();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const httpService = useHttpService();
 
@@ -106,7 +106,7 @@ export default function CreatePage() {
   };
 
   return appUser ? (
-    <PageLayout title="Create a game!">
+    <PageLayout title="Create a game!" loading={loadingAppUser}>
       <div className="grid grid-cols-2 gap-20">
         <CreatePageForm
           gameName={form.name}

--- a/client/src/pages/create/SignInToCreatePage.tsx
+++ b/client/src/pages/create/SignInToCreatePage.tsx
@@ -3,14 +3,16 @@ import PageLayout from "../../components/common/PageLayout";
 import { CircleCheckBig } from "lucide-react";
 import Button from "../../components/common/Button";
 import LoginSignUpModal, { LoginModalView } from "../login/LoginSignUpModal";
+import { useAuth } from "../../context/AuthProvider";
 
 export default function SignInToCreatePage() {
-  const [modalView, setModalView] = useState<
-    LoginModalView.LOGIN | LoginModalView.SIGNUP
-  >(LoginModalView.LOGIN);
+  const [modalView, setModalView] = useState<LoginModalView>(
+    LoginModalView.LOGIN
+  );
   const [showModal, setShowModal] = useState<boolean>(false);
+  const { loadingAppUser } = useAuth();
 
-  const openModal = (view: LoginModalView.LOGIN | LoginModalView.SIGNUP) => {
+  const openModal = (view: LoginModalView) => {
     setModalView(view);
     setShowModal(true);
   };
@@ -25,11 +27,12 @@ export default function SignInToCreatePage() {
     <PageLayout
       title="Create Your Own Wordle-like Game"
       description="Have a game idea? Join Makedle"
+      loading={loadingAppUser}
     >
       <div className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
-          {bulletPoints.map((bullet) => (
-            <div className="flex gap-2" key={bullet}>
+          {bulletPoints.map((bullet, index) => (
+            <div className="flex gap-2" key={index}>
               <CircleCheckBig />
               <div className="text-xl">{bullet}</div>
             </div>
@@ -38,7 +41,7 @@ export default function SignInToCreatePage() {
         <div className="flex flex-col gap-4">
           <Button
             onClick={() => openModal(LoginModalView.SIGNUP)}
-            className="self-center w-[150px]"
+            className="self-center w-36"
           >
             Sign Up
           </Button>

--- a/client/src/pages/games/GamesPage.tsx
+++ b/client/src/pages/games/GamesPage.tsx
@@ -3,9 +3,11 @@ import useHttpService from "../../api/useHttpService";
 import { Game } from "../../types/types";
 import GameItem from "./GameItem";
 import PageLayout from "../../components/common/PageLayout";
+import toast from "react-hot-toast";
 
 export default function GamesPage() {
   const [games, setGames] = useState([]);
+  const [loading, setLoading] = useState(false);
   const httpService = useHttpService();
 
   useEffect(() => {
@@ -13,13 +15,20 @@ export default function GamesPage() {
   }, []);
 
   const initGames = async () => {
-    const response = await httpService.get("/games");
-    const games = response.data;
-    setGames(games);
+    try {
+      setLoading(true);
+      const response = await httpService.get("/games");
+      const games = response.data;
+      setGames(games);
+    } catch {
+      toast.error("Issue loading games, try again later");
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
-    <PageLayout title="Games">
+    <PageLayout title="Games" loading={loading}>
       <div className="grid gap-4  sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         {games.map((game: Game) => (
           <GameItem key={game.id} game={game} />

--- a/client/src/pages/login/LoginPage.tsx
+++ b/client/src/pages/login/LoginPage.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import Button from "../../components/common/Button";
 import { useAuth } from "../../context/AuthProvider";
-import { useNavigate } from "react-router-dom";
 import _isEmpty from "lodash/isEmpty";
 
 type LoginFormUser = {
@@ -16,7 +15,6 @@ interface ILoginPageProps {
 export default function LoginPage({ goToSignUp }: ILoginPageProps) {
   const [user, setUser] = useState<LoginFormUser>({ email: "", password: "" });
   const { handleLogin } = useAuth();
-  const navigate = useNavigate();
 
   const changeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -27,7 +25,6 @@ export default function LoginPage({ goToSignUp }: ILoginPageProps) {
     e.preventDefault();
     try {
       await handleLogin(user);
-      navigate("/");
     } catch (error) {
       console.log(error);
     }


### PR DESCRIPTION
Adds a loading state for appUser in the Auth Context/provider. So if certain pages render differently(ie create game page) based on if used is logged in or not we can ensure we wait for the appUser to be set first.

Otherwise a LoadingPage will be shown which is now set in PageLayout component so easy access for all pages

Also an example for gamespage of a use case of loading on just the api not the appuser