### PR TITLE
Filter component and supportive components

### DIFF
--- a/client/src/components/ProfileMenu.tsx
+++ b/client/src/components/ProfileMenu.tsx
@@ -52,6 +52,7 @@ export default function ProfileMenu() {
         menuRef={menuRef}
         items={dropdownMenuItems}
         isProfile
+        direction="right"
       />
     </div>
   );

--- a/client/src/components/common/DropdownMenu.tsx
+++ b/client/src/components/common/DropdownMenu.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import _isEmpty from "lodash/isEmpty";
 import { useAuth } from "../../context/AuthProvider";
 import _some from "lodash/some";
-import { ISelectedItems } from "./FilterDropdown";
+import { SelectedItems } from "./FilterDropdown";
 
 interface IDropdownMenuProps {
   isOpen: boolean;
@@ -11,7 +11,7 @@ interface IDropdownMenuProps {
   fitParent?: boolean;
   isProfile?: boolean;
   isFilter?: boolean;
-  selectedItems?: ISelectedItems[];
+  selectedItems?: SelectedItems[];
   direction?: "right" | "left";
   textDirection?: "right" | "left" | "center";
   clearSearch?: (e: React.MouseEvent) => void;

--- a/client/src/components/common/DropdownMenu.tsx
+++ b/client/src/components/common/DropdownMenu.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import _isEmpty from "lodash/isEmpty";
 import { useAuth } from "../../context/AuthProvider";
+import _some from "lodash/some";
+import { ISelectedItems } from "./FilterDropdown";
 
 interface IDropdownMenuProps {
   isOpen: boolean;
@@ -8,11 +10,18 @@ interface IDropdownMenuProps {
   items: IDropdownMenuItems[];
   fitParent?: boolean;
   isProfile?: boolean;
+  isFilter?: boolean;
+  selectedItems?: ISelectedItems[];
+  direction?: "right" | "left";
+  textDirection?: "right" | "left" | "center";
+  clearSearch?: (e: React.MouseEvent) => void;
+  selectAllSearch?: (e: React.MouseEvent) => void;
 }
 
 export interface IDropdownMenuItems {
   name: string;
-  onClick: (event: React.MouseEvent) => void;
+  value?: string;
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 /* must exist within a relatively positioned element */
@@ -22,6 +31,12 @@ export default function DropdownMenu({
   items,
   fitParent = false,
   isProfile = false,
+  isFilter = false,
+  direction,
+  textDirection,
+  selectedItems, //type this
+  clearSearch,
+  selectAllSearch,
 }: IDropdownMenuProps) {
   const { appUser } = useAuth();
   return (
@@ -29,24 +44,56 @@ export default function DropdownMenu({
       {isOpen && !_isEmpty(items) && (
         <div
           ref={menuRef}
-          className={`absolute right-0 mt-2 ${
+          className={`absolute ${
+            direction === "right" ? "right-0" : "left-0"
+          } mt-2 ${
             fitParent ? "w-full" : "w-48"
           } bg-white rounded-lg shadow-lg border border-gray-200 z-10`}
         >
           {isProfile && (
             <>
-              <div className="w-full text-left px-4 py-2">
+              <div className="w-full text-left px-4 py-2 ">
                 {appUser?.username}
               </div>
               <hr />
             </>
           )}
+          {isFilter && (
+            <>
+              <button
+                className="w-full text-center px-4 py-2 hover:bg-gray-100"
+                onClick={
+                  _some(selectedItems, (item) => item.value)
+                    ? clearSearch
+                    : selectAllSearch
+                }
+              >
+                {_some(selectedItems, (item) => item.value)
+                  ? "Clear Search"
+                  : "Select All"}
+              </button>
+              <hr />
+            </>
+          )}
           <ul className="flex flex-col max-h-60 overflow-y-auto">
-            {items.map((item: IDropdownMenuItems) => (
-              <li key={item.name}>
+            {/* make scrollbar visible always */}
+            {items.map((item: IDropdownMenuItems, index) => (
+              <li key={item.name} className="flex hover:bg-gray-100">
+                {selectedItems && (
+                  <div className="w-[30%] flex items-center justify-center text-green-500 text-xl">
+                    {selectedItems[index] && selectedItems[index].value && "✓"}
+                  </div>
+                )}
                 <button
-                  className="w-full text-left px-4 py-2 hover:bg-gray-100"
+                  className={`w-full ${
+                    textDirection === "right"
+                      ? "text-right"
+                      : textDirection === "center"
+                      ? "text-center"
+                      : "text-left"
+                  } px-4 py-2`}
                   onClick={item.onClick}
+                  name={item.value}
                 >
                   {item.name}
                 </button>

--- a/client/src/components/common/FilterComponent.tsx
+++ b/client/src/components/common/FilterComponent.tsx
@@ -3,14 +3,23 @@ import Button from "./Button";
 import FilterDropdown from "./FilterDropdown";
 import { categoryOptions } from "../../pages/create/constants";
 
-export default function FilterComponent() {
+export type Filters = {
+  categories: string[],
+  keyword: string,
+  sortBy: string;
+}
+interface IFilterComponentProps {
+  setFilters: React.Dispatch<React.SetStateAction<Filters>>
+}
+
+export default function FilterComponent({setFilters}: IFilterComponentProps) {
   const [keyword, setKeyword] = useState("");
   const changeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = event.target;
     setKeyword(value);
   };
   return (
-    <div className="mb-8 flex justify-center gap-4">
+    <div className="mb-8 flex justify-center items-center gap-4">
       <div>
         <input
           type="text"
@@ -26,7 +35,7 @@ export default function FilterComponent() {
           Submit
         </Button>
       </div>
-      <FilterDropdown name={"Categories"} items={categoryOptions} />
+      <FilterDropdown name={"Categories"} items={categoryOptions} setFilters={setFilters}/>
     </div>
   );
 }

--- a/client/src/components/common/FilterComponent.tsx
+++ b/client/src/components/common/FilterComponent.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from "react";
+import Button from "./Button";
+import FilterDropdown from "./FilterDropdown";
+import { categoryOptions } from "../../pages/create/constants";
+
+export default function FilterComponent() {
+  const [keyword, setKeyword] = useState("");
+  const changeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+    setKeyword(value);
+  };
+  return (
+    <div className="mb-8 flex justify-center gap-4">
+      <div>
+        <input
+          type="text"
+          className="px-4 py-2 border rounded-l-md"
+          value={keyword}
+          onChange={changeHandler}
+          placeholder="Search..."
+        />
+        <Button
+          type="submit"
+          className="px-4 py-2 border rounded-r-md rounded-l-none"
+        >
+          Submit
+        </Button>
+      </div>
+      <FilterDropdown name={"Categories"} items={categoryOptions} />
+    </div>
+  );
+}

--- a/client/src/components/common/FilterDropdown.tsx
+++ b/client/src/components/common/FilterDropdown.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useRef, useState } from "react";
+import DropdownMenu, { IDropdownMenuItems } from "./DropdownMenu";
+import Button from "./Button";
+import { SelectOptions } from "../../pages/create/constants";
+
+interface IFilterDropdown {
+  name: string;
+  items: SelectOptions[];
+}
+
+export interface ISelectedItems {
+  name: string;
+  value: boolean;
+}
+
+export default function FilterDropdown({ name, items }: IFilterDropdown) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedItems, setSelectedItems] = useState<ISelectedItems[]>(
+    items.map((item) => ({ name: item.value, value: true }))
+  );
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const handleToggle = () => setIsOpen((prev) => !prev);
+
+  const toggleItem = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    const { name } = e.target as HTMLButtonElement;
+    setSelectedItems((prevItems) =>
+      prevItems.map((item) =>
+        item.name === name ? { ...item, value: !item.value } : item
+      )
+    );
+  };
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (
+      menuRef.current &&
+      !menuRef.current.contains(event.target as Node) &&
+      !(event.target as HTMLElement).closest("button")
+    ) {
+      setIsOpen(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const toggleAllItems = (e: React.MouseEvent, bool: boolean) => {
+    e.stopPropagation();
+    setSelectedItems((prevItems) =>
+      prevItems.map((item) => ({ ...item, value: bool }))
+    );
+  };
+
+  const dropdownItems: IDropdownMenuItems[] = items.map(
+    ({ content, value }: SelectOptions) => ({
+      name: content,
+      value,
+      onClick: toggleItem,
+    })
+  );
+
+  return (
+    <div className="relative" onClick={handleToggle}>
+      <Button>{name}</Button>
+      <DropdownMenu
+        isOpen={isOpen}
+        menuRef={menuRef}
+        items={dropdownItems}
+        isFilter
+        selectedItems={selectedItems}
+        clearSearch={(e) => toggleAllItems(e, false)}
+        selectAllSearch={(e) => toggleAllItems(e, true)}
+        textDirection="left"
+      />
+    </div>
+  );
+}

--- a/client/src/components/common/FilterDropdown.tsx
+++ b/client/src/components/common/FilterDropdown.tsx
@@ -2,21 +2,28 @@ import React, { useEffect, useRef, useState } from "react";
 import DropdownMenu, { IDropdownMenuItems } from "./DropdownMenu";
 import Button from "./Button";
 import { SelectOptions } from "../../pages/create/constants";
+import { ChevronDown } from "lucide-react";
+import { Filters } from "./FilterComponent";
 
 interface IFilterDropdown {
   name: string;
   items: SelectOptions[];
+  setFilters: React.Dispatch<React.SetStateAction<Filters>>;
 }
 
-export interface ISelectedItems {
+export interface SelectedItems {
   name: string;
   value: boolean;
 }
 
-export default function FilterDropdown({ name, items }: IFilterDropdown) {
+export default function FilterDropdown({
+  name,
+  items,
+  setFilters,
+}: IFilterDropdown) {
   const [isOpen, setIsOpen] = useState(false);
-  const [selectedItems, setSelectedItems] = useState<ISelectedItems[]>(
-    items.map((item) => ({ name: item.value, value: true }))
+  const [selectedItems, setSelectedItems] = useState<SelectedItems[]>(
+    items.map((item) => ({ name: item.value, value: false }))
   );
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -25,11 +32,14 @@ export default function FilterDropdown({ name, items }: IFilterDropdown) {
   const toggleItem = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     const { name } = e.target as HTMLButtonElement;
-    setSelectedItems((prevItems) =>
-      prevItems.map((item) =>
-        item.name === name ? { ...item, value: !item.value } : item
-      )
+    const newSelectedItems = selectedItems.map((item) =>
+      item.name === name ? { ...item, value: !item.value } : item
     );
+    setSelectedItems(newSelectedItems);
+    const newCategories = newSelectedItems
+      .filter((item) => item.value)
+      .map((item) => item.name);
+    setFilters((prev: Filters) => ({ ...prev, categories: newCategories }));
   };
 
   const handleClickOutside = (event: MouseEvent) => {
@@ -49,8 +59,16 @@ export default function FilterDropdown({ name, items }: IFilterDropdown) {
 
   const toggleAllItems = (e: React.MouseEvent, bool: boolean) => {
     e.stopPropagation();
-    setSelectedItems((prevItems) =>
-      prevItems.map((item) => ({ ...item, value: bool }))
+    const newSelectedItems = selectedItems.map((item) => ({
+      ...item,
+      value: bool,
+    }));
+    setSelectedItems(newSelectedItems);
+    const newCategories = newSelectedItems.map((item) => item.name);
+    setFilters((prev: Filters) =>
+      bool
+        ? { ...prev, categories: newCategories }
+        : { ...prev, categories: [] }
     );
   };
 
@@ -62,9 +80,26 @@ export default function FilterDropdown({ name, items }: IFilterDropdown) {
     })
   );
 
+  const getDisplayName = (): string => {
+    const selectedCount = selectedItems.filter(
+      (item) => item.value === true
+    ).length;
+    const selectedTotal = selectedItems.length;
+    if (selectedCount === selectedTotal) {
+      return name;
+    } else if (selectedCount === 0) {
+      return `No ${name}`;
+    } else {
+      return `${selectedCount}/${selectedTotal} ${name}`;
+    }
+  };
+
   return (
     <div className="relative" onClick={handleToggle}>
-      <Button>{name}</Button>
+      <Button className="flex">
+        <div>{getDisplayName()}</div>
+        <ChevronDown />
+      </Button>
       <DropdownMenu
         isOpen={isOpen}
         menuRef={menuRef}

--- a/client/src/pages/create/constants.ts
+++ b/client/src/pages/create/constants.ts
@@ -1,4 +1,9 @@
-export const categoryOptions = [
+export type SelectOptions = {
+  value: string;
+  content: string;
+};
+
+export const categoryOptions: SelectOptions[] = [
   { value: "anime", content: "Anime" },
   { value: "tv", content: "TV" },
   { value: "sports", content: "Sports" },

--- a/client/src/pages/games/GamesPage.tsx
+++ b/client/src/pages/games/GamesPage.tsx
@@ -5,6 +5,7 @@ import GameItem from "./GameItem";
 import PageLayout from "../../components/common/PageLayout";
 import toast from "react-hot-toast";
 import PaginatedList from "../../components/common/PaginatedList";
+import FilterComponent from "../../components/common/FilterComponent";
 
 const PAGE_SIZE_LIMIT = 20;
 
@@ -44,6 +45,7 @@ export default function GamesPage() {
 
   return (
     <PageLayout title="Games" loading={loading}>
+      <FilterComponent />
       <PaginatedList
         currentPage={currentPage}
         listLength={totalCount}

--- a/client/src/pages/games/GamesPage.tsx
+++ b/client/src/pages/games/GamesPage.tsx
@@ -5,13 +5,21 @@ import GameItem from "./GameItem";
 import PageLayout from "../../components/common/PageLayout";
 import toast from "react-hot-toast";
 import PaginatedList from "../../components/common/PaginatedList";
-import FilterComponent from "../../components/common/FilterComponent";
+import FilterComponent, {
+  Filters,
+} from "../../components/common/FilterComponent";
 
 const PAGE_SIZE_LIMIT = 20;
+const initFilters = {
+  categories: [],
+  keyword: "",
+  sortBy: "",
+};
 
 export default function GamesPage() {
   const [games, setGames] = useState([]);
   const [totalCount, setTotalCount] = useState(0);
+  const [filters, setFilters] = useState<Filters>(initFilters);
   const [loading, setLoading] = useState(true);
   const [currentPage, setCurrentPage] = useState(1);
   const httpService = useHttpService();
@@ -45,7 +53,7 @@ export default function GamesPage() {
 
   return (
     <PageLayout title="Games" loading={loading}>
-      <FilterComponent />
+      <FilterComponent setFilters={setFilters} />
       <PaginatedList
         currentPage={currentPage}
         listLength={totalCount}

--- a/client/src/pages/games/GamesPage.tsx
+++ b/client/src/pages/games/GamesPage.tsx
@@ -8,6 +8,7 @@ import PaginatedList from "../../components/common/PaginatedList";
 import FilterComponent, {
   Filters,
 } from "../../components/common/FilterComponent";
+import LoadingSpinner from "../../components/common/LoadingSpinner";
 
 const PAGE_SIZE_LIMIT = 20;
 const initFilters = {
@@ -26,7 +27,7 @@ export default function GamesPage() {
 
   useEffect(() => {
     getGames(currentPage);
-  }, [currentPage]);
+  }, [currentPage, filters]);
 
   const getGames = async (page: number) => {
     try {
@@ -35,6 +36,7 @@ export default function GamesPage() {
         params: {
           page,
           limit: PAGE_SIZE_LIMIT,
+          categories: filters.categories,
         },
       });
       const { games, totalCount } = response.data;
@@ -52,20 +54,24 @@ export default function GamesPage() {
   };
 
   return (
-    <PageLayout title="Games" loading={loading}>
+    <PageLayout title="Games">
       <FilterComponent setFilters={setFilters} />
-      <PaginatedList
-        currentPage={currentPage}
-        listLength={totalCount}
-        itemsPerPage={PAGE_SIZE_LIMIT}
-        onPageChange={handlePageChange}
-      >
-        <div className="grid gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {games.map((game: Game) => (
-            <GameItem key={game.id} game={game} />
-          ))}
-        </div>
-      </PaginatedList>
+      {loading ? (
+        <LoadingSpinner />
+      ) : (
+        <PaginatedList
+          currentPage={currentPage}
+          listLength={totalCount}
+          itemsPerPage={PAGE_SIZE_LIMIT}
+          onPageChange={handlePageChange}
+        >
+          <div className="grid gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {games.map((game: Game) => (
+              <GameItem key={game.id} game={game} />
+            ))}
+          </div>
+        </PaginatedList>
+      )}
     </PageLayout>
   );
 }

--- a/server/src/Controllers/GameController.ts
+++ b/server/src/Controllers/GameController.ts
@@ -19,11 +19,11 @@ export class GameController {
   }
 
   getGames = (req: Request, res: Response) => {
-    const { page = 1, limit = 10, sort = SortOrder.ASC } = req.query;
+    const { page = 1, limit = 10, categories, sort = SortOrder.ASC} = req.query;
     const pageNumber = parseInt(page as string, 10);
     const limitNumber = parseInt(limit as string, 10);
     this.gameModel
-      .getGames(pageNumber, limitNumber, sort as SortOrder)
+      .getGames(pageNumber, limitNumber, categories as string[], sort as SortOrder)
       .then(async ({ rows, totalCount }) => {
         const gamesWithBase64Images = await Promise.all(
           rows.map(async (game) => {


### PR DESCRIPTION
I probably should have broke this up into a few prs:

general gist is gamespage can now filter by a list of categories

what did i do in this pr

- Created `FilterComponent` which will house general filter sub components - keyword search, category search, date filter
- Created `FilterDropdown` pill dropdown to allow selection of items to adjust the FilterComponent and the parent state of filters to apply to page
- GamesPage now can make calls to get `/games` and filter by categories 
- `/games` endpoint getGames call now support search by categories i probably want to go back and start coming up with a smart way to make my queries to psql cleaner and scalable, its starting to get crowded and i want that logic more readable