### PR TITLE
HttpService edits

### DIFF
--- a/client/src/api/httpService.ts
+++ b/client/src/api/httpService.ts
@@ -1,18 +1,16 @@
 import axios from "axios";
 
-const httpService = axios.create({
-  baseURL: "http://localhost:3000/api",
-  timeout: 10000,
-  withCredentials: true,
-  headers: {
-    "x-makedle-header": "foobar",
-    // Authorization header will be set in the request interceptor
-  },
-});
+const TIMEOUT_DURATION = 10000; // 10 Seconds
+const API_BASE_URL = "http://localhost:3000/api"; // TODO add production url
 
-export const refreshHttpInstance = axios.create({
-  baseURL: "http://localhost:3000/api",
+const defaultConfig = {
+  baseURL: API_BASE_URL,
+  timeout: TIMEOUT_DURATION,
   withCredentials: true,
-});
+};
+
+const httpService = axios.create({ ...defaultConfig });
+
+export const refreshHttpInstance = axios.create({ ...defaultConfig });
 
 export default httpService;

--- a/client/src/api/useHttpService.ts
+++ b/client/src/api/useHttpService.ts
@@ -15,21 +15,21 @@ const useHttpService = () => {
         }
         return config;
       },
-      (error) => Promise.reject(error),
+      (error) => Promise.reject(error)
     );
 
     const responseIntercept = httpService.interceptors.response.use(
       (response) => response,
       async (error) => {
         const prevRequest = error?.config;
-        if (error?.response?.status === 403 && !prevRequest?.sent) {
-          prevRequest.sent = true;
+        if (error?.response?.status === 403 && !prevRequest?._retry) {
+          prevRequest._retry = true;
           const newToken = await refresh();
           prevRequest.headers["Authorization"] = `Bearer ${newToken}`;
           return httpService(prevRequest);
         }
         return Promise.reject(error);
-      },
+      }
     );
 
     return () => {

--- a/client/src/api/useRefreshToken.ts
+++ b/client/src/api/useRefreshToken.ts
@@ -5,9 +5,7 @@ const useRefreshToken = () => {
   const { setAccessToken } = useAuth();
 
   const refresh = async () => {
-    const response = await refreshHttpInstance.post("/refresh-token", {
-      withCredentials: true,
-    });
+    const response = await refreshHttpInstance.post("/refresh-token");
     setAccessToken(response.data.accessToken);
     return response.data.accessToken;
   };


### PR DESCRIPTION
## 📝 Description

Creates a common config for both axios instances. Reminder that we have two because one is specifically for refresh-token calls that does not have a request or response interceptor from the `useHttpService` hook.

`_retry` property suggestion to avoid conflict with a `sent` property on the request/prerequest

Fixes # (issue)

## ✅ Type of change

- [ ] Bug fix 🐛
- [ ] New feature ✨
- [ ] Breaking change 💥
- [x] Refactor 🔧
- [ ] Documentation update 📝
- [ ] Other: ****\_\_\_\_****

## 📸 Screenshots (if applicable)

_Please include any UI changes._

---

🧠 **Additional Notes**
Anything else reviewers should know? Links to official documentation backing up this change?
