### PR TITLE
Version endpoint, helmet and rate limit adjust

### DIFF
--- a/server/src/Routes/versionRoutes.ts
+++ b/server/src/Routes/versionRoutes.ts
@@ -1,0 +1,31 @@
+import { Router } from "express";
+import { execSync } from "child_process";
+import path from "path";
+import fs from "fs";
+
+const router = Router();
+
+const dirName = path.join(__dirname, "..", "..", "package.json")
+const packageJson = JSON.parse(fs.readFileSync(dirName, "utf8"));
+const appVersion = packageJson.version || "unknown";
+
+let gitSha = "unknown";
+try {
+  gitSha = execSync("git rev-parse HEAD").toString().trim();
+} catch {
+  console.log("Not in a git repo or git not available");
+}
+
+const buildTime = new Date().toISOString();
+
+router.get("/", (req, res) => {
+  res.json({
+    version: appVersion,
+    gitSha,
+    environment: process.env.NODE_ENV || "development",
+    buildTime,
+    uptimeSeconds: process.uptime(),
+  });
+});
+
+export default router;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,6 +7,7 @@ import authRoutes from "./Routes/authRoutes";
 import userRoutes from "./Routes/userRoutes";
 import gameRoutes from "./Routes/gameRoutes";
 import resultRoutes from "./Routes/resultRoutes";
+import versionRoutes from "./Routes/versionRoutes";
 import noCache from "./middleware/noCache";
 import { requestLogger } from "./middleware/requestLogger";
 import { apiLimiter } from "./middleware/rateLimiter";
@@ -38,6 +39,7 @@ if (fs.existsSync(CLIENT_DIR)) {
 }
 
 // ROUTES
+app.use("/version", versionRoutes);
 app.use("/api", authRoutes);
 app.use("/api", userRoutes);
 app.use("/api", gameRoutes);

--- a/server/src/middleware/helmet.ts
+++ b/server/src/middleware/helmet.ts
@@ -1,0 +1,10 @@
+import helmet from "helmet";
+
+export const helmetConfig = helmet({
+  contentSecurityPolicy: {
+    directives: {
+      ...helmet.contentSecurityPolicy.getDefaultDirectives(),
+      "img-src": ["'self'", "data:", "blob:", "https://placehold.co"],
+    },
+  },
+});

--- a/server/src/middleware/rateLimiter.ts
+++ b/server/src/middleware/rateLimiter.ts
@@ -1,0 +1,18 @@
+import rateLimit from "express-rate-limit";
+
+const RATE_LIMIT_MAX_REQUESTS = 200;
+const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000; // 15 mins
+
+export const apiLimiter = rateLimit({
+  windowMs: RATE_LIMIT_WINDOW_MS,
+  max: RATE_LIMIT_MAX_REQUESTS,
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) => {
+    res.status(429).json({
+      error: "Too many requests",
+      message:
+        "You have exceeded the limit of 1000 requests in 15 minutes. Please wait and try again",
+    });
+  },
+});


### PR DESCRIPTION
## 📝 Description

- Introduces `/version` endpoint
- move helmet and rate limit logic for readability

read a bit more about rate limiting i think 200 per 15. ex: 6 requests per minute per IP. Could look to play with this later still not 100% sure

Fixes # (issue)

## ✅ Type of change

- [ ] Bug fix 🐛
- [x] New feature ✨
- [ ] Breaking change 💥
- [x] Refactor 🔧
- [ ] Documentation update 📝
- [ ] Other: ****\_\_\_\_****

## 📸 Screenshots (if applicable)

_Please include any UI changes._

---

🧠 **Additional Notes**
Anything else reviewers should know? Links to official documentation backing up this change?
