### PR TITLE
MUI bug - no element that can hold a ref

### DIFF
--- a/client/src/pages/login/LoginSignUpModal.tsx
+++ b/client/src/pages/login/LoginSignUpModal.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import Modal from "@mui/material/Modal";
+import Box from "@mui/material/Box";
 import LoginForm from "./LoginForm";
 import SignUpForm from "./SignUpForm";
 
@@ -22,18 +23,18 @@ export default function LoginSignUpModal({
     }
   }, [isOpen, initLogin]);
 
+  const handleShowLogin = useCallback(() => setShowLogin(true), []);
+  const handleShowSignUp = useCallback(() => setShowLogin(false), []);
+
   return (
-    <Modal
-      open={isOpen}
-      onClose={handleClose}
-      aria-labelledby="modal-modal-title"
-      aria-describedby="modal-modal-description"
-    >
-      {showLogin ? (
-        <LoginForm showSignUp={() => setShowLogin(false)} />
-      ) : (
-        <SignUpForm showLogin={() => setShowLogin(true)} />
-      )}
+    <Modal open={isOpen} onClose={handleClose}>
+      <Box>
+        {showLogin ? (
+          <LoginForm showSignUp={handleShowSignUp} />
+        ) : (
+          <SignUpForm showLogin={handleShowLogin} />
+        )}
+      </Box>
     </Modal>
   );
 }


### PR DESCRIPTION
## 📝 Description

Small fix to deal with MUI type error
`
Warning: Failed prop type: Invalid prop children supplied to ForwardRef(Modal).
`

Fixes # (issue)

## ✅ Type of change

- [x] Bug fix 🐛
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Refactor 🔧
- [ ] Documentation update 📝
- [ ] Other: ****\_\_\_\_****

## 📸 Screenshots (if applicable)

_Please include any UI changes._

---

🧠 **Additional Notes**
Anything else reviewers should know? Links to official documentation backing up this change?
